### PR TITLE
Introduce RequestSender trait for overriding the sending process of requests to Fastly

### DIFF
--- a/src/rio.rs
+++ b/src/rio.rs
@@ -2,3 +2,4 @@ pub mod application;
 pub mod configuration;
 pub mod error;
 pub mod logging;
+pub mod request_sender;

--- a/src/rio/request_sender.rs
+++ b/src/rio/request_sender.rs
@@ -1,0 +1,17 @@
+use fastly::http::request::SendError;
+use fastly::{Request, Response};
+
+/// This trait is used to provide a way to override how requests are sent to Fastly backends.
+///
+/// The application may implement this trait and extend it with further logic such as header
+/// manipulation, or further caching logic.
+pub trait RequestSender {
+    #[allow(unused_mut)]
+    fn send(&self, req: Request, backend: String) -> Result<Response, SendError> {
+        return req.send(backend);
+    }
+}
+
+/// Default implementation for verbatim sending request to Fastly.
+pub struct DirectRequestSender;
+impl RequestSender for DirectRequestSender {}


### PR DESCRIPTION
Introduce RequestSender trait for overriding the sending process of requests to Fastly

The default implementation of the trait (DirectRequestSender) sends the requests verbatim to the given backend.

Other applications can implement that trait to allow altering of the request sent and/or the response received from Fastly.
Use cases include headers manipulation or adding additional caching logic.